### PR TITLE
Add option for reduction and project.dim to RunHarmony.Seurat

### DIFF
--- a/R/RunHarmony.R
+++ b/R/RunHarmony.R
@@ -276,7 +276,7 @@ RunHarmony.Seurat <- function(
     )
   } else {
     available.dimreduc <- names(methods::slot(object = object, name = 'reductions'))
-    if (!reduction %in% available.dimreduc) {
+    if (!(reduction %in% available.dimreduc)) {
       stop("Requested dimension reduction is not present in the Seurat object")
     }
     embedding <- Seurat::Embeddings(object, reduction = reduction)


### PR DESCRIPTION
Hi, I added a couple of options to `RunHarmony.Seurat` here to make it a bit more flexible with other data types (especially for scATAC-seq). Added the `reduction` argument to allow running on reductions other than PCA, and the `project.dim` argument to change whether the projection is run after running harmony.