### PR TITLE
fix idx_list bug

### DIFF
--- a/src/harmony.cpp
+++ b/src/harmony.cpp
@@ -192,14 +192,16 @@ int harmony::update_R() {
   _scale_dist = exp(_scale_dist);
 
   // GENERAL CASE: online updates, in blocks of size (N * block_size)
-  for (int i = 0; i < ceil(1. / block_size); i++) {    
+  int n_blocks = (int)(ceil(1.0 / block_size));
+  int cells_per_block = (N / n_blocks) + 1;
+  for (int i = 0; i < n_blocks; i++) {
     // gather cell updates indices
-    int idx_min = i * N * block_size;
-    int idx_max = min((int)((i + 1) * N * block_size), N - 1);
-    if (idx_min > idx_max) break; // TODO: fix the loop logic so that this never happens
-    uvec idx_list = linspace<uvec>(idx_min, idx_max, idx_max - idx_min + 1);
-    cells_update = update_order.rows(idx_list); 
-    
+    int idx_min = i * cells_per_block;
+    int idx_max = min(idx_min + cells_per_block, N);
+    if (idx_min > idx_max) break;
+    uvec idx_list = linspace<uvec>(idx_min, idx_max - 1, idx_max - idx_min);
+    cells_update = update_order.rows(idx_list);
+
     // Step 1: remove cells
     E -= sum(R.cols(cells_update), 1) * Pr_b.t();
     O -= R.cols(cells_update) * Phi.cols(cells_update).t();


### PR DESCRIPTION
This makes sure that each cell is included in a single block, instead of
including it in 2 blocks.

After this commit, I see the following:

```
idx_min 0
idx_max 5
idx_list         0        1        2        3        4

idx_min 5
idx_max 10
idx_list         5        6        7        8        9

idx_min 10
idx_max 15
idx_list         10        11        12        13        14

idx_min 15
idx_max 20
idx_list         15        16        17        18        19

...

idx_min 85
idx_max 90
idx_list         85        86        87        88        89

idx_min 90
idx_max 95
idx_list         90        91        92        93        94

idx_min 95
idx_max 97
idx_list         95        96
```

In contrast to issue #58, each cell is included a single block.

If you have a cleaner way to write this code, please go for it!