### PR TITLE
Change assay.use to default to DefaultAssay() instead of "RNA"

### DIFF
--- a/R/RunHarmony.R
+++ b/R/RunHarmony.R
@@ -1,51 +1,50 @@
 #' Harmony single cell integration
-#' 
-#' Run Harmony algorithm with Seurat and SingleCellAnalysis pipelines. 
-#' 
-#' @param object Pipeline object. Must have PCA computed. 
+#'
+#' Run Harmony algorithm with Seurat and SingleCellAnalysis pipelines.
+#'
+#' @param object Pipeline object. Must have PCA computed.
 #' @param group.by.vars Which variable(s) to remove (character vector).
 #' @param dims.use Which PCA dimensions to use for Harmony. By default, use all
-#' @param theta Diversity clustering penalty parameter. Specify for each 
+#' @param theta Diversity clustering penalty parameter. Specify for each
 #' variable in group.by.vars. Default theta=2. theta=0 does not encourage any
-#'  diversity. Larger values of theta result in more diverse clusters. 
-#' @param lambda Ridge regression penalty parameter. Specify for each variable 
-#' in group.by.vars. Default lambda=1. Lambda must be strictly positive. 
-#' Smaller values result in more aggressive correction. 
-#' @param sigma Width of soft kmeans clusters. Default sigma=0.1. Sigma scales 
+#'  diversity. Larger values of theta result in more diverse clusters.
+#' @param lambda Ridge regression penalty parameter. Specify for each variable
+#' in group.by.vars. Default lambda=1. Lambda must be strictly positive.
+#' Smaller values result in more aggressive correction.
+#' @param sigma Width of soft kmeans clusters. Default sigma=0.1. Sigma scales
 #' the distance from a cell to cluster centroids. Larger values of sigma result
-#'  in cells assigned to more clusters. Smaller values of sigma make soft 
-#'  kmeans cluster approach hard clustering. 
+#'  in cells assigned to more clusters. Smaller values of sigma make soft
+#'  kmeans cluster approach hard clustering.
 #' @param nclust Number of clusters in model. nclust=1 equivalent to simple
-#'  linear regression. 
+#'  linear regression.
 #' @param tau Protection against overclustering small datasets with large ones.
-#'  tau is the expected number of cells per cluster. 
+#'  tau is the expected number of cells per cluster.
 #' @param block.size What proportion of cells to update during clustering.
-#'  Between 0 to 1, default 0.05. Larger values may be faster but less accurate 
-#' @param max.iter.cluster Maximum number of rounds to run clustering at each 
-#' round of Harmony. 
+#'  Between 0 to 1, default 0.05. Larger values may be faster but less accurate
+#' @param max.iter.cluster Maximum number of rounds to run clustering at each
+#' round of Harmony.
 #' @param epsilon.cluster Convergence tolerance for clustering round of Harmony
-#'  Set to -Inf to never stop early. 
+#'  Set to -Inf to never stop early.
 #' @param max.iter.harmony Maximum number of rounds to run Harmony. One round
-#'  of Harmony involves one clustering and one correction step. 
+#'  of Harmony involves one clustering and one correction step.
 #' @param epsilon.harmony Convergence tolerance for Harmony. Set to -Inf to
-#'  never stop early. 
-#' @param plot_convergence Whether to print the convergence plot of the 
+#'  never stop early.
+#' @param plot_convergence Whether to print the convergence plot of the
 #' clustering objective function. TRUE to plot, FALSE to suppress. This can be
-#'  useful for debugging. 
+#'  useful for debugging.
 #' @param verbose Whether to print progress messages. TRUE to print, FALSE to
 #'  suppress.
 #' @param reference_values (Advanced Usage) Defines reference dataset(s). Cells
 #' that have batch variables values matching reference_values will not be moved
 #' @param reduction.save Keyword to save Harmony reduction. Useful if you want
-#' to try Harmony with multiple parameters and save them as e.g. 
+#' to try Harmony with multiple parameters and save them as e.g.
 #' 'harmony_theta0', 'harmony_theta1', 'harmony_theta2'
-#' @param assay.use (Seurat V3 only) Which assay to Harmonize with (RNA 
-#' by default). 
-#' @param ... other parameters 
-#' 
-#' 
+#' @param assay.use (Seurat V3 only) Which assay to Harmonize with (Default Assay as default).
+#' @param ... other parameters
+#'
+#'
 #' @rdname RunHarmony
-#' @export 
+#' @export
 RunHarmony <- function(object, group.by.vars, ...) {
     UseMethod("RunHarmony")
 }
@@ -78,10 +77,11 @@ RunHarmony.Seurat <- function(
   verbose = TRUE,
   reference_values = NULL,
   reduction.save = "harmony",
-  assay.use = 'RNA',
+  assay.use = NULL,
   project.dim = TRUE,
   ...
 ) {
+  assay.use <- assay.use %||% DefaultAssay(object)
   if (reduction == "pca") {
     tryCatch(
       embedding <- Seurat::Embeddings(object, reduction = "pca"),
@@ -170,77 +170,77 @@ RunHarmony.Seurat <- function(
 
 #' @rdname RunHarmony
 #' @return SingleCellExperiment object. After running RunHarmony, the corrected
-#' cell embeddings can be accessed with reducedDim(object, "Harmony"). 
+#' cell embeddings can be accessed with reducedDim(object, "Harmony").
 #' @export
 RunHarmony.SingleCellExperiment <- function(
-    object, 
-    group.by.vars, 
-    dims.use = NULL, 
-    theta = NULL, 
-    lambda = NULL, 
-    sigma = 0.1, 
-    nclust = NULL, 
-    tau = 0, 
-    block.size = 0.05, 
-    max.iter.harmony = 10, 
-    max.iter.cluster = 20, 
-    epsilon.cluster = 1e-5, 
-    epsilon.harmony = 1e-4, 
-    plot_convergence = FALSE, 
-    verbose = TRUE, 
+    object,
+    group.by.vars,
+    dims.use = NULL,
+    theta = NULL,
+    lambda = NULL,
+    sigma = 0.1,
+    nclust = NULL,
+    tau = 0,
+    block.size = 0.05,
+    max.iter.harmony = 10,
+    max.iter.cluster = 20,
+    epsilon.cluster = 1e-5,
+    epsilon.harmony = 1e-4,
+    plot_convergence = FALSE,
+    verbose = TRUE,
     reference_values = NULL,
     reduction.save = "HARMONY",
     ...
 ) {
-    
-    ## Get PCA embeddings 
+
+    ## Get PCA embeddings
     if (!"PCA" %in% SingleCellExperiment::reducedDimNames(object)) {
         stop("PCA must be computed before running Harmony.")
     }
     pca_embedding <- SingleCellExperiment::reducedDim(object, "PCA")
     if (is.null(dims.use)) {
         dims.use <- seq_len(ncol(pca_embedding))
-    } 
-    
+    }
+
     if (is.null(dims.use)) {
         dims.use <- seq_len(ncol(pca_embedding))
-    } 
+    }
     dims_avail <- seq_len(ncol(pca_embedding))
     if (!all(dims.use %in% dims_avail)) {
-        stop("trying to use more dimensions than computed with PCA. Rereun 
+        stop("trying to use more dimensions than computed with PCA. Rereun
             PCA with more dimensions or use fewer PCs")
     }
-    
+
     metavars_df <- SingleCellExperiment::colData(object)
     if (!all(group.by.vars %in% colnames(metavars_df))) {
         stop('Trying to integrate over variables missing in colData')
     }
-    
+
     harmonyEmbed <- HarmonyMatrix(
         pca_embedding,
         metavars_df,
-        group.by.vars, 
-        FALSE, 
-        0, 
-        theta, 
-        lambda, 
-        sigma, 
-        nclust, 
-        tau, 
-        block.size, 
-        max.iter.harmony, 
+        group.by.vars,
+        FALSE,
+        0,
+        theta,
+        lambda,
+        sigma,
+        nclust,
+        tau,
+        block.size,
+        max.iter.harmony,
         max.iter.cluster,
-        epsilon.cluster, 
+        epsilon.cluster,
         epsilon.harmony,
-        plot_convergence, 
-        FALSE, 
-        verbose, 
+        plot_convergence,
+        FALSE,
+        verbose,
         reference_values
     )
-    
+
     rownames(harmonyEmbed) <- row.names(metavars_df)
     colnames(harmonyEmbed) <- paste0(reduction.save, "_", seq_len(ncol(harmonyEmbed)))
     SingleCellExperiment::reducedDim(object, reduction.save) <- harmonyEmbed
-    
+
     return(object)
 }

--- a/R/harmony-package.r
+++ b/R/harmony-package.r
@@ -1,22 +1,22 @@
-#' Harmony: fast, accurate, and robust single cell integration. 
+#' Harmony: fast, accurate, and robust single cell integration.
 #'
-#' Algorithm for single cell integration. 
+#' Algorithm for single cell integration.
 #'
-#' @section Usage: 
-#' 
+#' @section Usage:
+#'
 #' \enumerate{
-#' \item ?HarmonyMatrix to run Harmony on gene expression or PCA 
+#' \item ?HarmonyMatrix to run Harmony on gene expression or PCA
 #' embeddings matrix.
 #' \item ?RunHarmony to run Harmony on Seurat or SingleCellExperiment objects.
 #' }
 #' @section Useful links:
-#' 
+#'
 #' \enumerate{
 #' \item Report bugs at \url{https://github.com/immunogenomics/harmony/issues}
 #' \item Read the manuscript
 #' \href{https://www.biorxiv.org/content/10.1101/461954v2}{online}.
 #' }
-#' 
+#'
 #'
 #' @name harmony
 #' @docType package
@@ -28,5 +28,6 @@
 #' @importFrom methods is
 #' @importFrom cowplot plot_grid
 #' @importFrom rlang .data
+#' @importFrom rlang `%||%`
 loadModule("harmony_module", TRUE)
 NULL


### PR DESCRIPTION
Given the tools provided by the Satija lab where a Seurat object has a built in default, I have always thought it perplexing why Harmony always defaults to RNA. Here I changed the required lines (81 and 84) and it seems RStudio removed many spaces. I think this change makes the method for Seurat objects fit better in the existing structure of Seurat. 