### PR TITLE
Rename local pow() to avoid issue with next Armadillo

### DIFF
--- a/src/harmony.cpp
+++ b/src/harmony.cpp
@@ -208,7 +208,7 @@ int harmony::update_R() {
 
     // Step 2: recompute R for removed cells
     R.cols(cells_update) = _scale_dist.cols(cells_update);    
-    R.cols(cells_update) = R.cols(cells_update) % (pow((E + 1) / (O + 1), theta) * Phi.cols(cells_update));
+    R.cols(cells_update) = R.cols(cells_update) % (harmony_pow((E + 1) / (O + 1), theta) * Phi.cols(cells_update));
     R.cols(cells_update) = normalise(R.cols(cells_update), 1, 0); // L1 norm columns
     
     // Step 3: put cells back 

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,7 +24,7 @@ MATTYPE safe_entropy(const MATTYPE& X) {
 
 
 // Overload pow to work on a MATTYPErix and vector
-MATTYPE pow(MATTYPE A, const VECTYPE & T) {
+MATTYPE harmony_pow(MATTYPE A, const VECTYPE & T) {
   for (unsigned c = 0; c < A.n_cols; c++) {
     A.col(c) = pow(A.col(c), as_scalar(T.row(c)));
   }


### PR DESCRIPTION
Hi harmony team,

The next release of Armadillo will have a slightly expanded `arma::pow()` function. In `harmony` you flatten the namespace so your local `pow()` helper then gets confused with what (Rcpp)Armadillo will bring.  One possible fix (suggested by Conrad) is to rename your helper; this PR does that.  I tested it first against the release tarball and now against git, and `R CMD check` continues to pass.

It would be helpful to if you could update `harmony` with a simple spot release as we then will not have to discuss 'changes' with CRAN.  We will probably look into releasing a new `RcppArmadillo` within two or three weeks.  You are of course under no obligation to change this, but are likely to then hear from the CRAN maintainers with firmer language <wink>.

Let us know if you have questions.  

Cheers,  Dirk