### PR TITLE
[FIX] BLAS thread detection misbehaving on CRAN build systems

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: harmony
 Title: Fast, Sensitive, and Accurate Integration of Single Cell Data
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
     person("Ilya", "Korsunsky", email = "ilya.korsunsky@gmail.com",
         role = c("cre", "aut"), comment = c(ORCID = "0000-0003-4848-3948")),


### PR DESCRIPTION
Gracefully failing and falling back on a configuration path that does not invoke set threads command if omp_get_max_threads() return gibberish values like NA.

Fixes failed tests on OSX in CRAN