### PR TITLE
Fix ssl problem in bioc_install command

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,8 @@ environment:
     R_ARCH: x64
     USE_RTOOLS: true
     R_CHECK_ARGS: "--no-manual --timings"
+    R_LIBCURL_SSL_REVOKE_BEST_EFFORT: "TRUE"
+    CURL_SSL_BACKEND: "openssl"
 
   matrix:
   - R_VERSION: release


### PR DESCRIPTION
# Problem
Currently, the tests fail at the first bioc_install command because of SSL error

For example:

```
package 'BiocManager' successfully unpacked and MD5 sums checked
The downloaded binary packages are in
	C:\Users\appveyor\AppData\Local\Temp\1\Rtmpai2tJU\downloaded_packages
Error: Bioconductor version cannot be validated; no internet connection?  See
  #troubleshooting section in vignette
In addition: Warning messages:
1: In file(con, "r") :
  URL 'https://bioconductor.org/config.yaml': status was 'SSL connect error'
2: In file(con, "r") :
  URL 'https://bioconductor.org/config.yaml': status was 'SSL connect error'
Execution halted
Command exited with code 1
7z a failure.zip *.Rcheck\*
7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21
```

# Fix
Set R_LIBCURL_SSL_REVOKE_BEST_EFFORT to TRUE (see https://stat.ethz.ch/R-manual/R-devel/library/utils/html/download.file.html for details)
and set curl backend to `openssl` using `CURL_SSL_BACKEND` variable.