### PR TITLE
Startup message tweaks

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,21 +1,23 @@
 #' @importFrom utils packageVersion vignette
 .onAttach <- function(libname, pkgname) {
-    ver = packageVersion(pkgname)
-    vignette_built = nrow(vignette(package = 'harmony')$results) != 0
+  ver = packageVersion(pkgname)
+  vignette_built = nrow(vignette(package = 'harmony')$results) != 0
 
-    if (vignette_built) {
-        rebuild_advice = ""
-    } else {
-        rebuild_advice = "Reinstall with {.code build_vignettes = TRUE}, then "
-    }
+  if (vignette_built) {
+    rebuild_advice = ""
+  } else {
+    rebuild_advice = "Reinstall with {.code build_vignettes = TRUE}, then "
+  }
 
-    vign_emph = cli::combine_ansi_styles("bold", "red2")
+  vign_emph = cli::combine_ansi_styles("bold", "red2")
 
-    vignette_msg = paste0('{cli::symbol$bullet} {.strong Read the guide}: ',
-                          rebuild_advice,
-                          'run {vign_emph("vignette()")}')
+  vignette_msg = paste0('{cli::symbol$bullet} {.strong Read the guide}: ',
+                        rebuild_advice,
+                        'run {vign_emph(\'vignette(\"quickstart\", package=\"harmony\")\')}')
 
-    cli::cli_inform(paste0("{cli::symbol$bullet} This is Harmony2 version {.strong ", ver, "}"), class = "packageStartupMessage")
-    cli::cli_inform(vignette_msg, class = "packageStartupMessage")
-    cli::cli_inform("{cli::symbol$bullet} {.strong Get help}: Visit the website at https://korsunskylab.github.io/harmony2/ and report issues on https://github.com/immunogenomics/harmony/issues", class = "packageStartupMessage")
+  cli::cli_inform(paste0("{cli::symbol$bullet} This is Harmony2 version {.strong ", ver, "}"), class = "packageStartupMessage")
+  cli::cli_inform(vignette_msg, class = "packageStartupMessage")
+  cli::cli_inform("{cli::symbol$bullet} {.strong Get help}: Visit the website at {.url https://korsunskylab.github.io/harmony2/} and report issues on {.url https://github.com/immunogenomics/harmony/issues}", class = "packageStartupMessage")
 }
+
+


### PR DESCRIPTION
I was using harmony for a work project recently and noticed that the new startup message [looked a bit familiar](https://github.com/biobakery/anpan/blob/1d08004666b664ef843809ab34a09deb7f2faa2a/R/zzz.R) 😉 so I thought I would submit a cheeky PR with a few helpful tweaks. This PR:

1. Makes the links to the website and issue page clickable
2. edits the suggested vignette command to open harmony's quickstart vignette specifically (calling `vignette()` with no arguments opens a list of all vignettes from all packages on the user's machine)

The startup message now looks like this:

<img width="2024" height="426" alt="Screenshot from 2026-05-25 17-08-22" src="https://github.com/user-attachments/assets/c749b9e6-c621-42c1-bce9-4fa818012ec5" />
